### PR TITLE
fix: allow `outpainting` a source_processing type

### DIFF
--- a/horde/classes/stable/waiting_prompt.py
+++ b/horde/classes/stable/waiting_prompt.py
@@ -41,7 +41,7 @@ class ImageWaitingPrompt(WaitingPrompt):
     width = db.Column(db.Integer, default=512, nullable=False, server_default=expression.literal(512))
     height = db.Column(db.Integer, default=512, nullable=False, server_default=expression.literal(512))
     source_image = db.Column(db.Text, default=None)
-    source_processing = db.Column(db.String(10), default="img2img", nullable=False, server_default="img2img")
+    source_processing = db.Column(db.String(12), default="img2img", nullable=False, server_default="img2img")
     source_mask = db.Column(db.Text, default=None)
     censor_nsfw = db.Column(
         db.Boolean,

--- a/sql_statements/4.49.0.txt
+++ b/sql_statements/4.49.0.txt
@@ -1,0 +1,1 @@
+ALTER TABLE waiting_prompts ALTER COLUMN source_processing TYPE VARCHAR(12);

--- a/sql_statements/4.49.0.txt.license
+++ b/sql_statements/4.49.0.txt.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: Tazlin <tazlin.on.github@gmail.com>
+
+SPDX-License-Identifier: AGPL-3.0-or-later


### PR DESCRIPTION
`outpainting` is allowed as a `source_processing` value, but prior to this change setting this value will cause a 500 stemming from a `sqlalchemy.exc.DataError: (psycopg2.errors.StringDataRightTruncation) value too long for type character varying(10)` error.

This change allows the intended number of characters, plus an extra one for posterity.